### PR TITLE
Load faces VAE model from cwd

### DIFF
--- a/2. Faces VAE.ipynb
+++ b/2. Faces VAE.ipynb
@@ -1794,8 +1794,8 @@
    },
    "outputs": [],
    "source": [
-    "# Load saved model with the most recent timestamp.",
-    "t.model_file = [f for f in sorted(os.listdir()) if f.startswith(\"faces_vae_\")][-1]",
+    "# Load saved model with the most recent timestamp.\n",
+    "t.model_file = [f for f in sorted(os.listdir()) if f.startswith(\"faces_vae_\")][-1]\n",
     "t.model = torch.load(t.model_file)"
    ]
   },

--- a/2. Faces VAE.ipynb
+++ b/2. Faces VAE.ipynb
@@ -1794,7 +1794,9 @@
    },
    "outputs": [],
    "source": [
-    "t.model = torch.load(\"pretrained-models/faces_vae.pkl\")"
+    "# Load saved model with the most recent timestamp.",
+    "t.model_file = [f for f in sorted(os.listdir()) if f.startswith(\"faces_vae_\")][-1]",
+    "t.model = torch.load(t.model_file)"
    ]
   },
   {

--- a/2. Faces VAE.ipynb
+++ b/2. Faces VAE.ipynb
@@ -1794,7 +1794,7 @@
    },
    "outputs": [],
    "source": [
-    "# Load saved model with the most recent timestamp.\n",
+    "# Load model with most recent timestamp.\n",
     "t.model_file = [f for f in sorted(os.listdir()) if f.startswith(\"faces_vae_\")][-1]\n",
     "t.model = torch.load(t.model_file)"
    ]


### PR DESCRIPTION
Notebook execution was failing when trying to load model from `pretrained-models` folder since it seems to be saved in cwd during training - this change loads model from there instead.